### PR TITLE
Exome seq changes to run with toil

### DIFF
--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -2753,6 +2753,10 @@
                 {
                     "valueFrom": "MarkDuplicates", 
                     "position": 0
+                }, 
+                {
+                    "valueFrom": "CREATE_INDEX=True", 
+                    "position": 0
                 }
             ], 
             "id": "#picard-MarkDuplicates.cwl"

--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -3754,6 +3754,9 @@
                 }, 
                 {
                     "type": "File", 
+                    "secondaryFiles": [
+                        ".idx"
+                    ], 
                     "id": "#main/indel_resource_mills"
                 }, 
                 {
@@ -3815,18 +3818,30 @@
                 }, 
                 {
                     "type": "File", 
+                    "secondaryFiles": [
+                        ".idx"
+                    ], 
                     "id": "#main/resource_dbsnp"
                 }, 
                 {
                     "type": "File", 
+                    "secondaryFiles": [
+                        ".idx"
+                    ], 
                     "id": "#main/snp_resource_1kg"
                 }, 
                 {
                     "type": "File", 
+                    "secondaryFiles": [
+                        ".idx"
+                    ], 
                     "id": "#main/snp_resource_hapmap"
                 }, 
                 {
                     "type": "File", 
+                    "secondaryFiles": [
+                        ".idx"
+                    ], 
                     "id": "#main/snp_resource_omni"
                 }, 
                 {

--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -3771,6 +3771,9 @@
                         "type": "array", 
                         "items": "File"
                     }, 
+                    "secondaryFiles": [
+                        ".idx"
+                    ], 
                     "id": "#main/knownSites"
                 }, 
                 {
@@ -3789,6 +3792,15 @@
                 }, 
                 {
                     "type": "File", 
+                    "secondaryFiles": [
+                        ".amb", 
+                        ".ann", 
+                        ".bwt", 
+                        ".pac", 
+                        ".sa", 
+                        ".fai", 
+                        "^.dict"
+                    ], 
                     "id": "#main/reference_genome"
                 }, 
                 {
@@ -3796,6 +3808,9 @@
                         "type": "array", 
                         "items": "File"
                     }, 
+                    "secondaryFiles": [
+                        "^.bai"
+                    ], 
                     "id": "#main/reference_reads"
                 }, 
                 {

--- a/tools/picard-MarkDuplicates.cwl
+++ b/tools/picard-MarkDuplicates.cwl
@@ -55,4 +55,6 @@ arguments:
   prefix: -jar
 - valueFrom: MarkDuplicates
   position: 0
+- valueFrom: "CREATE_INDEX=True"
+  position: 0
 

--- a/workflows/exomeseq.cwl
+++ b/workflows/exomeseq.cwl
@@ -34,21 +34,37 @@ inputs:
   # Read Group annotation
   read_group_header: string
   # GATK
-  GATKJar: File
+  GATKJar:
+    type: File
   knownSites:
     type: File[] # vcf files of known sites, with indexing
     secondaryFiles:
-      - .idx
+    - .idx
   # Confidence threshold for calling a variant - 30
   stand_call_conf: double
   # Variant Recalibration - SNPs
-  snp_resource_hapmap: File
-  snp_resource_omni: File
-  snp_resource_1kg: File
+  snp_resource_hapmap:
+    type: File
+    secondaryFiles:
+    - .idx
+  snp_resource_omni:
+    type: File
+    secondaryFiles:
+    - .idx
+  snp_resource_1kg: 
+    type: File
+    secondaryFiles:
+      - .idx
   # Variant Recalibration - Common
-  resource_dbsnp: File
+  resource_dbsnp:
+    type: File
+    secondaryFiles:
+    - .idx
   # Variant Recalibration - Indels
-  indel_resource_mills: File
+  indel_resource_mills:
+    type: File
+    secondaryFiles:
+    - .idx
 outputs:
   qc_reports:
     type: { type: array, items: { type: array, items: File } }

--- a/workflows/exomeseq.cwl
+++ b/workflows/exomeseq.cwl
@@ -14,16 +14,31 @@ inputs:
   # Read pairs, fastq format
   read_pairs:
       type: { type: array, items: { type: array, items: File } }
-  reference_reads: File[]
+  reference_reads:
+    type: File[]
+    secondaryFiles:
+    - ^.bai
   # reference genome, fasta
-  reference_genome: File
+  reference_genome:
+    type: File
+    secondaryFiles:
+    - .amb
+    - .ann
+    - .bwt
+    - .pac
+    - .sa
+    - .fai
+    - ^.dict
   # Number of threads to use
   threads: int?
   # Read Group annotation
   read_group_header: string
   # GATK
   GATKJar: File
-  knownSites: File[] # vcf files of known sites, with indexing
+  knownSites:
+    type: File[] # vcf files of known sites, with indexing
+    secondaryFiles:
+      - .idx
   # Confidence threshold for calling a variant - 30
   stand_call_conf: double
   # Variant Recalibration - SNPs


### PR DESCRIPTION
Adds duplicated secondaryFiles info from child tool workflows since toil doesn't seem to find this data. This can be removed once that is fixed in toil.

Changes picard tool to create a secondary index file.


