### PR TITLE
Corrects input of variant calibration INDELS

### DIFF
--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -2627,7 +2627,7 @@
                     "id": "#generate-joint-filenames.cwl/snps_vqsr_tranches_output_filename"
                 }
             ], 
-            "expression": "${\n  function makeFilename(base, suffix, extension) {\n    return base + '-' + suffix + '.' + extension;\n  }\n  var base = inputs.name\n\n  return {\n    joint_genotype_raw_variants_output_filename: makeFilename(base, 'raw_variants', 'g.vcf'),\n    snps_vqsr_recal_output_filename: makeFilename(base, 'snps_vqsr_recal', 'out'),\n    snps_vqsr_tranches_output_filename: makeFilename(base, 'snps_vqsr_tranches', 'out'),\n    snps_vqsr_rscript_output_filename: makeFilename(base, 'snps_vqsr', 'R'),\n    snps_recalibrated_output_filename: makeFilename(base, 'snps_recalibrated', 'vcf'),\n    indels_vqsr_recal_output_filename: makeFilename(base, 'indels_vqsr_recal', 'out'),\n    indels_vqsr_tranches_output_filename: makeFilename(base, 'indels_vqsr_tranches', 'out'),\n    indels_vqsr_rscript_output_filename: makeFilename(base, 'indels_vqsr', 'R'),\n    indels_recalibrated_output_filename: makeFilename(base, 'indels_recalibrated', 'vcf')\n  };\n}\n", 
+            "expression": "${\n  function makeFilename(base, suffix, extension) {\n    return base + '-' + suffix + '.' + extension;\n  }\n  var base = inputs.name\n\n  return {\n    joint_genotype_raw_variants_output_filename: makeFilename(base, 'raw_variants', 'g.vcf'),\n    snps_vqsr_recal_output_filename: makeFilename(base, 'snps_vqsr_recal', 'out'),\n    snps_vqsr_tranches_output_filename: makeFilename(base, 'snps_vqsr_tranches', 'out'),\n    snps_vqsr_rscript_output_filename: makeFilename(base, 'snps_vqsr', 'R'),\n    snps_recalibrated_output_filename: makeFilename(base, 'recalibrated_snps_raw_indels', 'vcf'),\n    indels_vqsr_recal_output_filename: makeFilename(base, 'indels_vqsr_recal', 'out'),\n    indels_vqsr_tranches_output_filename: makeFilename(base, 'indels_vqsr_tranches', 'out'),\n    indels_vqsr_rscript_output_filename: makeFilename(base, 'indels_vqsr', 'R'),\n    indels_recalibrated_output_filename: makeFilename(base, 'recalibrated_variants', 'vcf')\n  };\n}\n", 
             "id": "#generate-joint-filenames.cwl"
         }, 
         {
@@ -3596,7 +3596,7 @@
                             "id": "#exomeseq-02-variantdiscovery.cwl/apply_recalibration_indels/ts_filter_level"
                         }, 
                         {
-                            "source": "#exomeseq-02-variantdiscovery.cwl/joint_genotyping/output_GenotypeGVCFs", 
+                            "source": "#exomeseq-02-variantdiscovery.cwl/apply_recalibration_snps/output_recalibrated_vcf", 
                             "id": "#exomeseq-02-variantdiscovery.cwl/apply_recalibration_indels/variants"
                         }
                     ], 
@@ -3772,7 +3772,7 @@
                             "id": "#exomeseq-02-variantdiscovery.cwl/variant_recalibration_indels/threads"
                         }, 
                         {
-                            "source": "#exomeseq-02-variantdiscovery.cwl/joint_genotyping/output_GenotypeGVCFs", 
+                            "source": "#exomeseq-02-variantdiscovery.cwl/apply_recalibration_snps/output_recalibrated_vcf", 
                             "id": "#exomeseq-02-variantdiscovery.cwl/variant_recalibration_indels/variants"
                         }
                     ], 

--- a/tools/generate-joint-filenames.cwl
+++ b/tools/generate-joint-filenames.cwl
@@ -31,10 +31,10 @@ expression: >
       snps_vqsr_recal_output_filename: makeFilename(base, 'snps_vqsr_recal', 'out'),
       snps_vqsr_tranches_output_filename: makeFilename(base, 'snps_vqsr_tranches', 'out'),
       snps_vqsr_rscript_output_filename: makeFilename(base, 'snps_vqsr', 'R'),
-      snps_recalibrated_output_filename: makeFilename(base, 'snps_recalibrated', 'vcf'),
+      snps_recalibrated_output_filename: makeFilename(base, 'recalibrated_snps_raw_indels', 'vcf'),
       indels_vqsr_recal_output_filename: makeFilename(base, 'indels_vqsr_recal', 'out'),
       indels_vqsr_tranches_output_filename: makeFilename(base, 'indels_vqsr_tranches', 'out'),
       indels_vqsr_rscript_output_filename: makeFilename(base, 'indels_vqsr', 'R'),
-      indels_recalibrated_output_filename: makeFilename(base, 'indels_recalibrated', 'vcf')
+      indels_recalibrated_output_filename: makeFilename(base, 'recalibrated_variants', 'vcf')
     };
   }

--- a/workflows/exomeseq-02-variantdiscovery.cwl
+++ b/workflows/exomeseq-02-variantdiscovery.cwl
@@ -153,7 +153,7 @@ steps:
     in:
       GATKJar: GATKJar
       reference: reference_genome
-      variants: joint_genotyping/output_GenotypeGVCFs
+      variants: apply_recalibration_snps/output_recalibrated_vcf
       threads:
         default: 1
       outputfile_recal: generate_joint_filenames/indels_vqsr_recal_output_filename
@@ -178,7 +178,7 @@ steps:
     in:
       GATKJar: GATKJar
       reference: reference_genome
-      variants: joint_genotyping/output_GenotypeGVCFs
+      variants: apply_recalibration_snps/output_recalibrated_vcf
       threads: threads
       tranches_file: variant_recalibration_indels/tranches_File
       recal_file: variant_recalibration_indels/recal_File


### PR DESCRIPTION
Per https://software.broadinstitute.org/gatk/documentation/article?id=2805, the input of the INDEL variant calibration step should be the output VCF of the SNP variant calibration, not the raw variants.

Fixes #19 