### PR TITLE
Exome Seq: read_pairs format info

### DIFF
--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -3927,7 +3927,8 @@
                         "type": "array", 
                         "items": {
                             "type": "array", 
-                            "items": "File"
+                            "items": "File", 
+                            "format": "http://edamontology.org/format_1930"
                         }
                     }, 
                     "id": "#main/read_pairs"

--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -3059,10 +3059,7 @@
                     "id": "#exomeseq-01-preprocessing.cwl/qc_reports"
                 }, 
                 {
-                    "type": {
-                        "type": "array", 
-                        "items": "File"
-                    }, 
+                    "type": "File", 
                     "outputSource": "#exomeseq-01-preprocessing.cwl/variant_calling/output_HaplotypeCaller", 
                     "doc": "VCF files from per sample variant calling", 
                     "id": "#exomeseq-01-preprocessing.cwl/raw_variants"

--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -3927,10 +3927,10 @@
                         "type": "array", 
                         "items": {
                             "type": "array", 
-                            "items": "File", 
-                            "format": "http://edamontology.org/format_1930"
+                            "items": "File"
                         }
                     }, 
+                    "format": "http://edamontology.org/format_1930", 
                     "id": "#main/read_pairs"
                 }, 
                 {

--- a/workflows/exomeseq-01-preprocessing.cwl
+++ b/workflows/exomeseq-01-preprocessing.cwl
@@ -47,7 +47,7 @@ outputs:
     type: File
     outputSource: recalibrate_02_apply/output_printReads
   raw_variants:
-    type: File[]
+    type: File
     outputSource: variant_calling/output_HaplotypeCaller
     doc: "VCF files from per sample variant calling"
 steps:

--- a/workflows/exomeseq.cwl
+++ b/workflows/exomeseq.cwl
@@ -13,7 +13,8 @@ inputs:
   interval_padding: int?
   # Read pairs, fastq format
   read_pairs:
-      type: { type: array, items: { type: array, items: File, format: http://edamontology.org/format_1930 } }
+      type: { type: array, items: { type: array, items: File }} 
+      format: http://edamontology.org/format_1930
   # reference genome, fasta
   reference_genome:
     type: File

--- a/workflows/exomeseq.cwl
+++ b/workflows/exomeseq.cwl
@@ -1,5 +1,4 @@
 #!/usr/bin/env cwl-runner
-
 cwlVersion: v1.0
 class: Workflow
 label: Whole Exome Sequencing
@@ -14,7 +13,7 @@ inputs:
   interval_padding: int?
   # Read pairs, fastq format
   read_pairs:
-      type: { type: array, items: { type: array, items: File } }
+      type: { type: array, items: { type: array, items: File, format: http://edamontology.org/format_1930 } }
   # reference genome, fasta
   reference_genome:
     type: File

--- a/workflows/exomeseq.cwl
+++ b/workflows/exomeseq.cwl
@@ -14,7 +14,7 @@ inputs:
   # Read pairs, fastq format
   read_pairs:
       type: { type: array, items: { type: array, items: File }} 
-      format: http://edamontology.org/format_1930
+      format: http://edamontology.org/format_1930 # FASTQ format
   # reference genome, fasta
   reference_genome:
     type: File


### PR DESCRIPTION
Adds format=FASTQ to input read_pairs is format.
Also fixes #22 by fixing the type for raw_variants.