### PR TITLE
Exome seq qc picard

### DIFF
--- a/examples/exome-seq/exomeseq-01-preprocessing.json
+++ b/examples/exome-seq/exomeseq-01-preprocessing.json
@@ -9,6 +9,12 @@
       "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_capture.noChr.bed"
     }
   ],
+  "primary_intervals": [
+    {
+      "class": "File",
+      "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_primary.noChr.bed"
+    }
+  ],
   "knownSites": [
     {
       "class": "File",

--- a/examples/exome-seq/exomeseq-02-variantdiscovery.json
+++ b/examples/exome-seq/exomeseq-02-variantdiscovery.json
@@ -13,6 +13,12 @@
       "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_capture.noChr.bed"
     }
   ],
+  "primary_intervals": [
+    {
+      "class": "File",
+      "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_primary.noChr.bed"
+    }
+  ],
   "mapped_reads": [
     {
         "checksum": "sha1$fe26a1074884a4d55c96b46aa62dfe3022598718",

--- a/examples/exome-seq/exomeseq-03-01.json
+++ b/examples/exome-seq/exomeseq-03-01.json
@@ -9,6 +9,12 @@
       "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_capture.noChr.bed"
     }
   ],
+  "primary_intervals": [
+    {
+      "class": "File",
+      "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_primary.noChr.bed"
+    }
+  ],
   "reference_genome": {
     "class": "File",
     "path": "/home/ubuntu/data/b37/human_g1k_v37.fasta"

--- a/examples/exome-seq/exomeseq-bespin.json
+++ b/examples/exome-seq/exomeseq-bespin.json
@@ -13,6 +13,12 @@
       "path": "/data/exome-seq/capture/SeqCap_EZ_Exome_v3_capture.noChr.bed"
     }
   ],
+  "primary_intervals": [
+    {
+      "class": "File",
+      "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_primary.noChr.bed"
+    }
+  ],
   "interval_padding": 100,
   "knownSites": [
     {

--- a/examples/exome-seq/exomeseq-bespin.json
+++ b/examples/exome-seq/exomeseq-bespin.json
@@ -16,7 +16,7 @@
   "primary_intervals": [
     {
       "class": "File",
-      "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_primary.noChr.bed"
+      "path": "/data/exome-seq/capture/SeqCap_EZ_Exome_v3_primary.noChr.bed"
     }
   ],
   "interval_padding": 100,

--- a/examples/exome-seq/exomeseq.json
+++ b/examples/exome-seq/exomeseq.json
@@ -13,6 +13,12 @@
       "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_capture.noChr.bed"
     }
   ],
+  "primary_intervals": [
+    {
+      "class": "File",
+      "path": "/home/ubuntu/data/capture/SeqCap_EZ_Exome_v3_primary.noChr.bed"
+    }
+  ],
   "interval_padding": 100,
   "knownSites": [
     {

--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -2655,6 +2655,10 @@
                 }, 
                 {
                     "type": "string", 
+                    "id": "#generate-sample-filenames.cwl/hs_metrics_output_filename"
+                }, 
+                {
+                    "type": "string", 
                     "id": "#generate-sample-filenames.cwl/mapped_reads_output_filename"
                 }, 
                 {
@@ -2674,7 +2678,7 @@
                     "id": "#generate-sample-filenames.cwl/sorted_reads_output_filename"
                 }
             ], 
-            "expression": "${\n  function makeFilename(base, suffix, extension) {\n    return base + '-' + suffix + '.' + extension;\n  }\n  var base = inputs.sample_name\n\n  return {\n    mapped_reads_output_filename: makeFilename(base, 'mapped', 'bam'),\n    sorted_reads_output_filename: makeFilename(base, 'sorted', 'bam'),\n    dedup_reads_output_filename: makeFilename(base, 'dedup', 'bam'),\n    dedup_metrics_output_filename: makeFilename(base, 'dedup-metrics', 'out'),\n    recal_reads_output_filename: makeFilename(base, 'recal', 'bam'),\n    recal_table_output_filename: makeFilename(base, 'recal', 'table'),\n    raw_variants_output_filename: makeFilename(base, 'raw_variants', 'g.vcf')\n  };\n}\n", 
+            "expression": "${\n  function makeFilename(base, suffix, extension) {\n    return base + '-' + suffix + '.' + extension;\n  }\n  var base = inputs.sample_name\n\n  return {\n    mapped_reads_output_filename: makeFilename(base, 'mapped', 'bam'),\n    sorted_reads_output_filename: makeFilename(base, 'sorted', 'bam'),\n    dedup_reads_output_filename: makeFilename(base, 'dedup', 'bam'),\n    dedup_metrics_output_filename: makeFilename(base, 'dedup-metrics', 'out'),\n    recal_reads_output_filename: makeFilename(base, 'recal', 'bam'),\n    recal_table_output_filename: makeFilename(base, 'recal', 'table'),\n    raw_variants_output_filename: makeFilename(base, 'raw_variants', 'g.vcf'),\n    hs_metrics_output_filename: makeFilename(base, 'hs', 'txt')\n  };\n}\n", 
             "id": "#generate-sample-filenames.cwl"
         }, 
         {
@@ -2736,6 +2740,177 @@
             ], 
             "expression": "${\n  // Returns the part of the filename before the extension\n  function removeExtension(name) {\n    return name.split('.')[0];\n  }\n\n  // Given an array of keys and values, creates an object mapping keys to values\n  function zip(keys, values) {\n    var object = {};\n    for (var i=0;i<keys.length;i++) {\n      object[keys[i]] = values[i]\n    }\n    return object;\n  }\n\n  // Split the string name on the separator\n  function splitFields(name, separator) {\n  \treturn name.split(separator);\n  }\n\n  // Makes a string with a read group header that can be provided to bwa as SAM metadata\n  function makeReadGroupsString(fields) {\n    \tvar readGroups = \"@RG\" +\n    \t  \"\\\\tID:\" + fields['sample'] +\n    \t  \"\\\\tLB:\" + fields['library'] +\n    \t  \"\\\\tPL:\" + fields['platform'] +\n    \t  \"\\\\tPU:\" + fields['sample'] +\n    \t  \"\\\\tSM:\" + fields['sample'];\n      return readGroups;\n  }\n\n  var filename = inputs.reads[0].basename;\n  var base = removeExtension(filename);\n  var components = splitFields(base, inputs.separator);\n  var fields = zip(inputs.field_order, components);\n  fields['library'] = inputs.library;\n  fields['platform'] = inputs.platform;\n  var read_group_header = makeReadGroupsString(fields);\n  return {\n    read_group_header: read_group_header,\n    sample_name: fields['sample']\n  };\n}\n", 
             "id": "#parse-read-group-header.cwl"
+        }, 
+        {
+            "class": "CommandLineTool", 
+            "requirements": [
+                {
+                    "class": "DockerRequirement", 
+                    "dockerPull": "dukegcb/picard:2.10.7"
+                }, 
+                {
+                    "class": "InlineJavascriptRequirement"
+                }
+            ], 
+            "inputs": [
+                {
+                    "type": [
+                        "null", 
+                        {
+                            "type": "array", 
+                            "items": "File"
+                        }
+                    ], 
+                    "doc": "The bed file to be converted to interval_list format.  Required.", 
+                    "inputBinding": {
+                        "prefix": "I=", 
+                        "shellQuote": false
+                    }, 
+                    "id": "#picard-BedToIntervalList.cwl/input_file"
+                }, 
+                {
+                    "type": "File", 
+                    "doc": "The reference sequences in fasta format.", 
+                    "inputBinding": {
+                        "prefix": "SD=", 
+                        "shellQuote": false
+                    }, 
+                    "id": "#picard-BedToIntervalList.cwl/reference_sequence"
+                }
+            ], 
+            "outputs": [
+                {
+                    "type": [
+                        "null", 
+                        {
+                            "type": "array", 
+                            "items": "File"
+                        }
+                    ], 
+                    "outputBinding": {
+                        "glob": "$(inputs.input_file.path + '.interval_list')"
+                    }, 
+                    "id": "#picard-BedToIntervalList.cwl/output_interval_list_file"
+                }
+            ], 
+            "baseCommand": [
+                "java", 
+                "-Xmx4g"
+            ], 
+            "arguments": [
+                {
+                    "valueFrom": "/opt/picard/picard.jar", 
+                    "position": -1, 
+                    "prefix": "-jar"
+                }, 
+                {
+                    "valueFrom": "BedToIntervalList", 
+                    "position": 0
+                }, 
+                {
+                    "valueFrom": "$(inputs.input_file.path + '.interval_list')", 
+                    "prefix": "O=", 
+                    "separate": false
+                }
+            ], 
+            "id": "#picard-BedToIntervalList.cwl"
+        }, 
+        {
+            "class": "CommandLineTool", 
+            "requirements": [
+                {
+                    "class": "DockerRequirement", 
+                    "dockerPull": "dukegcb/picard:2.10.7"
+                }, 
+                {
+                    "class": "InlineJavascriptRequirement"
+                }
+            ], 
+            "inputs": [
+                {
+                    "type": {
+                        "type": "array", 
+                        "items": "File"
+                    }, 
+                    "doc": "The bait interval file in picard interval_list format (from capture kit).", 
+                    "inputBinding": {
+                        "prefix": "BAIT_INTERVALS=", 
+                        "shellQuote": false
+                    }, 
+                    "id": "#picard-CollectHsMetrics.cwl/bait_intervals"
+                }, 
+                {
+                    "type": "File", 
+                    "doc": "The BAM or SAM file to collect metrics from.  Required.", 
+                    "inputBinding": {
+                        "prefix": "I=", 
+                        "shellQuote": false
+                    }, 
+                    "id": "#picard-CollectHsMetrics.cwl/input_file"
+                }, 
+                {
+                    "type": [
+                        "null", 
+                        "string"
+                    ], 
+                    "doc": "The metrics output filename.", 
+                    "default": "hs_metrics.txt", 
+                    "inputBinding": {
+                        "prefix": "O=", 
+                        "shellQuote": false
+                    }, 
+                    "id": "#picard-CollectHsMetrics.cwl/output_filename"
+                }, 
+                {
+                    "type": "File", 
+                    "doc": "The reference sequences in fasta format.", 
+                    "inputBinding": {
+                        "prefix": "R=", 
+                        "shellQuote": false
+                    }, 
+                    "id": "#picard-CollectHsMetrics.cwl/reference_sequence"
+                }, 
+                {
+                    "type": {
+                        "type": "array", 
+                        "items": "File"
+                    }, 
+                    "doc": "The target interval file in picard interval_list format (from capture kit).", 
+                    "inputBinding": {
+                        "prefix": "TARGET_INTERVALS=", 
+                        "shellQuote": false
+                    }, 
+                    "id": "#picard-CollectHsMetrics.cwl/target_intervals"
+                }
+            ], 
+            "outputs": [
+                {
+                    "type": {
+                        "type": "array", 
+                        "items": "File"
+                    }, 
+                    "outputBinding": {
+                        "glob": "$(inputs.output_filename)"
+                    }, 
+                    "id": "#picard-CollectHsMetrics.cwl/output_hs_metrics_file"
+                }
+            ], 
+            "baseCommand": [
+                "java", 
+                "-Xmx4g"
+            ], 
+            "arguments": [
+                {
+                    "valueFrom": "/opt/picard/picard.jar", 
+                    "position": -1, 
+                    "prefix": "-jar"
+                }, 
+                {
+                    "valueFrom": "CollectHsMetrics", 
+                    "position": 0
+                }
+            ], 
+            "id": "#picard-CollectHsMetrics.cwl"
         }, 
         {
             "class": "CommandLineTool", 
@@ -3027,6 +3202,16 @@
                     "id": "#exomeseq-01-preprocessing.cwl/platform"
                 }, 
                 {
+                    "type": [
+                        "null", 
+                        {
+                            "type": "array", 
+                            "items": "File"
+                        }
+                    ], 
+                    "id": "#exomeseq-01-preprocessing.cwl/primary_intervals"
+                }, 
+                {
                     "type": {
                         "type": "array", 
                         "items": "File"
@@ -3055,14 +3240,19 @@
                         "type": "array", 
                         "items": "File"
                     }, 
-                    "outputSource": "#exomeseq-01-preprocessing.cwl/qc/output_qc_report", 
-                    "id": "#exomeseq-01-preprocessing.cwl/qc_reports"
+                    "outputSource": "#exomeseq-01-preprocessing.cwl/collect_hs_metrics/output_hs_metrics_file", 
+                    "id": "#exomeseq-01-preprocessing.cwl/hs_metrics"
                 }, 
                 {
                     "type": {
                         "type": "array", 
                         "items": "File"
                     }, 
+                    "outputSource": "#exomeseq-01-preprocessing.cwl/qc/output_qc_report", 
+                    "id": "#exomeseq-01-preprocessing.cwl/qc_reports"
+                }, 
+                {
+                    "type": "File", 
                     "outputSource": "#exomeseq-01-preprocessing.cwl/variant_calling/output_HaplotypeCaller", 
                     "doc": "VCF files from per sample variant calling", 
                     "id": "#exomeseq-01-preprocessing.cwl/raw_variants"
@@ -3088,6 +3278,44 @@
             ], 
             "steps": [
                 {
+                    "run": "#picard-CollectHsMetrics.cwl", 
+                    "requirements": [
+                        {
+                            "class": "ResourceRequirement", 
+                            "coresMin": 1, 
+                            "ramMin": 4000, 
+                            "outdirMin": 12000, 
+                            "tmpdirMin": 12000
+                        }
+                    ], 
+                    "in": [
+                        {
+                            "source": "#exomeseq-01-preprocessing.cwl/make_bait_interval_list/output_interval_list_file", 
+                            "id": "#exomeseq-01-preprocessing.cwl/collect_hs_metrics/bait_intervals"
+                        }, 
+                        {
+                            "source": "#exomeseq-01-preprocessing.cwl/mark_duplicates/output_dedup_bam_file", 
+                            "id": "#exomeseq-01-preprocessing.cwl/collect_hs_metrics/input_file"
+                        }, 
+                        {
+                            "source": "#exomeseq-01-preprocessing.cwl/generate_sample_filenames/hs_metrics_output_filename", 
+                            "id": "#exomeseq-01-preprocessing.cwl/collect_hs_metrics/output_filename"
+                        }, 
+                        {
+                            "source": "#exomeseq-01-preprocessing.cwl/reference_genome", 
+                            "id": "#exomeseq-01-preprocessing.cwl/collect_hs_metrics/reference_sequence"
+                        }, 
+                        {
+                            "source": "#exomeseq-01-preprocessing.cwl/make_target_interval_list/output_interval_list_file", 
+                            "id": "#exomeseq-01-preprocessing.cwl/collect_hs_metrics/target_intervals"
+                        }
+                    ], 
+                    "out": [
+                        "#exomeseq-01-preprocessing.cwl/collect_hs_metrics/output_hs_metrics_file"
+                    ], 
+                    "id": "#exomeseq-01-preprocessing.cwl/collect_hs_metrics"
+                }, 
+                {
                     "run": "#generate-sample-filenames.cwl", 
                     "in": [
                         {
@@ -3102,9 +3330,62 @@
                         "#exomeseq-01-preprocessing.cwl/generate_sample_filenames/dedup_metrics_output_filename", 
                         "#exomeseq-01-preprocessing.cwl/generate_sample_filenames/recal_reads_output_filename", 
                         "#exomeseq-01-preprocessing.cwl/generate_sample_filenames/recal_table_output_filename", 
-                        "#exomeseq-01-preprocessing.cwl/generate_sample_filenames/raw_variants_output_filename"
+                        "#exomeseq-01-preprocessing.cwl/generate_sample_filenames/raw_variants_output_filename", 
+                        "#exomeseq-01-preprocessing.cwl/generate_sample_filenames/hs_metrics_output_filename"
                     ], 
                     "id": "#exomeseq-01-preprocessing.cwl/generate_sample_filenames"
+                }, 
+                {
+                    "run": "#picard-BedToIntervalList.cwl", 
+                    "requirements": [
+                        {
+                            "class": "ResourceRequirement", 
+                            "coresMin": 1, 
+                            "ramMin": 4000, 
+                            "outdirMin": 12000, 
+                            "tmpdirMin": 12000
+                        }
+                    ], 
+                    "in": [
+                        {
+                            "source": "#exomeseq-01-preprocessing.cwl/primary_intervals", 
+                            "id": "#exomeseq-01-preprocessing.cwl/make_bait_interval_list/input_file"
+                        }, 
+                        {
+                            "source": "#exomeseq-01-preprocessing.cwl/reference_genome", 
+                            "id": "#exomeseq-01-preprocessing.cwl/make_bait_interval_list/reference_sequence"
+                        }
+                    ], 
+                    "out": [
+                        "#exomeseq-01-preprocessing.cwl/make_bait_interval_list/output_interval_list_file"
+                    ], 
+                    "id": "#exomeseq-01-preprocessing.cwl/make_bait_interval_list"
+                }, 
+                {
+                    "run": "#picard-BedToIntervalList.cwl", 
+                    "requirements": [
+                        {
+                            "class": "ResourceRequirement", 
+                            "coresMin": 1, 
+                            "ramMin": 4000, 
+                            "outdirMin": 12000, 
+                            "tmpdirMin": 12000
+                        }
+                    ], 
+                    "in": [
+                        {
+                            "source": "#exomeseq-01-preprocessing.cwl/intervals", 
+                            "id": "#exomeseq-01-preprocessing.cwl/make_target_interval_list/input_file"
+                        }, 
+                        {
+                            "source": "#exomeseq-01-preprocessing.cwl/reference_genome", 
+                            "id": "#exomeseq-01-preprocessing.cwl/make_target_interval_list/reference_sequence"
+                        }
+                    ], 
+                    "out": [
+                        "#exomeseq-01-preprocessing.cwl/make_target_interval_list/output_interval_list_file"
+                    ], 
+                    "id": "#exomeseq-01-preprocessing.cwl/make_target_interval_list"
                 }, 
                 {
                     "run": "#bwa-mem-samtools.cwl", 
@@ -3923,6 +4204,16 @@
                     "id": "#main/platform"
                 }, 
                 {
+                    "type": [
+                        "null", 
+                        {
+                            "type": "array", 
+                            "items": "File"
+                        }
+                    ], 
+                    "id": "#main/primary_intervals"
+                }, 
+                {
                     "type": {
                         "type": "array", 
                         "items": {
@@ -3982,6 +4273,17 @@
                 }
             ], 
             "outputs": [
+                {
+                    "type": {
+                        "type": "array", 
+                        "items": {
+                            "type": "array", 
+                            "items": "File"
+                        }
+                    }, 
+                    "outputSource": "#main/preprocessing/hs_metrics", 
+                    "id": "#main/hs_metrics"
+                }, 
                 {
                     "type": "File", 
                     "outputSource": "#main/variant_discovery/joint_raw_variants", 
@@ -4139,7 +4441,8 @@
                         "#main/preprocessing/trim_reports", 
                         "#main/preprocessing/recalibration_table", 
                         "#main/preprocessing/recalibrated_reads", 
-                        "#main/preprocessing/raw_variants"
+                        "#main/preprocessing/raw_variants", 
+                        "#main/preprocessing/hs_metrics"
                     ], 
                     "id": "#main/preprocessing"
                 }, 

--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -4424,6 +4424,10 @@
                             "id": "#main/preprocessing/platform"
                         }, 
                         {
+                            "source": "#main/primary_intervals", 
+                            "id": "#main/preprocessing/primary_intervals"
+                        }, 
+                        {
                             "source": "#main/read_pairs", 
                             "id": "#main/preprocessing/reads"
                         }, 

--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -2769,6 +2769,19 @@
                     "id": "#picard-BedToIntervalList.cwl/input_file"
                 }, 
                 {
+                    "type": [
+                        "null", 
+                        "string"
+                    ], 
+                    "doc": "Interval list output filename.", 
+                    "default": "list.interval_list", 
+                    "inputBinding": {
+                        "prefix": "O=", 
+                        "shellQuote": false
+                    }, 
+                    "id": "#picard-BedToIntervalList.cwl/output_filename"
+                }, 
+                {
                     "type": "File", 
                     "doc": "The reference sequences in fasta format.", 
                     "inputBinding": {
@@ -2780,15 +2793,9 @@
             ], 
             "outputs": [
                 {
-                    "type": [
-                        "null", 
-                        {
-                            "type": "array", 
-                            "items": "File"
-                        }
-                    ], 
+                    "type": "File", 
                     "outputBinding": {
-                        "glob": "$(inputs.input_file.path + '.interval_list')"
+                        "glob": "$(inputs.output_filename)"
                     }, 
                     "id": "#picard-BedToIntervalList.cwl/output_interval_list_file"
                 }
@@ -2806,11 +2813,6 @@
                 {
                     "valueFrom": "BedToIntervalList", 
                     "position": 0
-                }, 
-                {
-                    "valueFrom": "$(inputs.input_file.path + '.interval_list')", 
-                    "prefix": "O=", 
-                    "separate": false
                 }
             ], 
             "id": "#picard-BedToIntervalList.cwl"
@@ -2828,10 +2830,7 @@
             ], 
             "inputs": [
                 {
-                    "type": {
-                        "type": "array", 
-                        "items": "File"
-                    }, 
+                    "type": "File", 
                     "doc": "The bait interval file in picard interval_list format (from capture kit).", 
                     "inputBinding": {
                         "prefix": "BAIT_INTERVALS=", 
@@ -2871,10 +2870,7 @@
                     "id": "#picard-CollectHsMetrics.cwl/reference_sequence"
                 }, 
                 {
-                    "type": {
-                        "type": "array", 
-                        "items": "File"
-                    }, 
+                    "type": "File", 
                     "doc": "The target interval file in picard interval_list format (from capture kit).", 
                     "inputBinding": {
                         "prefix": "TARGET_INTERVALS=", 
@@ -3352,6 +3348,10 @@
                             "id": "#exomeseq-01-preprocessing.cwl/make_bait_interval_list/input_file"
                         }, 
                         {
+                            "default": "bait.interval_list", 
+                            "id": "#exomeseq-01-preprocessing.cwl/make_bait_interval_list/output_filename"
+                        }, 
+                        {
                             "source": "#exomeseq-01-preprocessing.cwl/reference_genome", 
                             "id": "#exomeseq-01-preprocessing.cwl/make_bait_interval_list/reference_sequence"
                         }
@@ -3376,6 +3376,10 @@
                         {
                             "source": "#exomeseq-01-preprocessing.cwl/intervals", 
                             "id": "#exomeseq-01-preprocessing.cwl/make_target_interval_list/input_file"
+                        }, 
+                        {
+                            "default": "target.interval_list", 
+                            "id": "#exomeseq-01-preprocessing.cwl/make_target_interval_list/output_filename"
                         }, 
                         {
                             "source": "#exomeseq-01-preprocessing.cwl/reference_genome", 

--- a/tools/generate-sample-filenames.cwl
+++ b/tools/generate-sample-filenames.cwl
@@ -16,6 +16,7 @@ outputs:
   recal_reads_output_filename: string
   recal_table_output_filename: string
   raw_variants_output_filename: string
+  hs_metrics_output_filename: string
 
 expression: >
   ${
@@ -31,6 +32,7 @@ expression: >
       dedup_metrics_output_filename: makeFilename(base, 'dedup-metrics', 'out'),
       recal_reads_output_filename: makeFilename(base, 'recal', 'bam'),
       recal_table_output_filename: makeFilename(base, 'recal', 'table'),
-      raw_variants_output_filename: makeFilename(base, 'raw_variants', 'g.vcf')
+      raw_variants_output_filename: makeFilename(base, 'raw_variants', 'g.vcf'),
+      hs_metrics_output_filename: makeFilename(base, 'hs', 'txt')
     };
   }

--- a/tools/picard-BedToIntervalList.cwl
+++ b/tools/picard-BedToIntervalList.cwl
@@ -1,0 +1,42 @@
+#!/usr/bin/env cwl-runner
+# https://broadinstitute.github.io/picard/command-line-overview.html#CollectHsMetrics
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+requirements:
+- class: DockerRequirement
+  dockerPull: dukegcb/picard:2.10.7
+- class: InlineJavascriptRequirement
+
+inputs:
+  input_file:
+    type: File[]?
+    doc: "The bed file to be converted to interval_list format.  Required."
+    inputBinding:
+      prefix: "I="
+      shellQuote: false
+  reference_sequence:
+    type: File
+    doc: "The reference sequences in fasta format."
+    inputBinding:
+      prefix: "SD="
+      shellQuote: false
+outputs:
+  output_interval_list_file:
+    type: File[]?
+    outputBinding:
+      glob: $(inputs.input_file.path + '.interval_list')
+
+baseCommand: ["java", "-Xmx4g"]
+arguments:
+- valueFrom: "/opt/picard/picard.jar"
+  position: -1
+  prefix: -jar
+- valueFrom: BedToIntervalList
+  position: 0
+- valueFrom: $(inputs.input_file.path + '.interval_list')
+  prefix: "O="
+  separate: false
+
+

--- a/tools/picard-BedToIntervalList.cwl
+++ b/tools/picard-BedToIntervalList.cwl
@@ -16,6 +16,13 @@ inputs:
     inputBinding:
       prefix: "I="
       shellQuote: false
+  output_filename:
+    type: string?
+    doc: "Interval list output filename."
+    default: "list.interval_list"
+    inputBinding:
+      prefix: "O="
+      shellQuote: false
   reference_sequence:
     type: File
     doc: "The reference sequences in fasta format."
@@ -24,9 +31,9 @@ inputs:
       shellQuote: false
 outputs:
   output_interval_list_file:
-    type: File[]?
+    type: File
     outputBinding:
-      glob: $(inputs.input_file.path + '.interval_list')
+      glob: $(inputs.output_filename)
 
 baseCommand: ["java", "-Xmx4g"]
 arguments:
@@ -35,8 +42,3 @@ arguments:
   prefix: -jar
 - valueFrom: BedToIntervalList
   position: 0
-- valueFrom: $(inputs.input_file.path + '.interval_list')
-  prefix: "O="
-  separate: false
-
-

--- a/tools/picard-BedToIntervalList.cwl
+++ b/tools/picard-BedToIntervalList.cwl
@@ -1,5 +1,5 @@
 #!/usr/bin/env cwl-runner
-# https://broadinstitute.github.io/picard/command-line-overview.html#CollectHsMetrics
+# https://broadinstitute.github.io/picard/command-line-overview.html#BedToIntervalList
 
 cwlVersion: v1.0
 class: CommandLineTool

--- a/tools/picard-CollectHsMetrics.cwl
+++ b/tools/picard-CollectHsMetrics.cwl
@@ -30,20 +30,20 @@ inputs:
       prefix: "R="
       shellQuote: false
   bait_intervals:
-    type: File
+    type: File[]
     doc: "The bait interval file in picard interval_list format (from capture kit)."
     inputBinding:
       prefix: "BAIT_INTERVALS="
       shellQuote: false
   target_intervals:
-    type: File
+    type: File[]
     doc: "The target interval file in picard interval_list format (from capture kit)."
     inputBinding:
       prefix: "TARGET_INTERVALS="
       shellQuote: false
 outputs:
-  sorted:
-    type: File
+  output_hs_metrics_file:
+    type: File[]
     outputBinding:
       glob: $(inputs.output_filename)
 

--- a/tools/picard-CollectHsMetrics.cwl
+++ b/tools/picard-CollectHsMetrics.cwl
@@ -30,13 +30,13 @@ inputs:
       prefix: "R="
       shellQuote: false
   bait_intervals:
-    type: File[]
+    type: File
     doc: "The bait interval file in picard interval_list format (from capture kit)."
     inputBinding:
       prefix: "BAIT_INTERVALS="
       shellQuote: false
   target_intervals:
-    type: File[]
+    type: File
     doc: "The target interval file in picard interval_list format (from capture kit)."
     inputBinding:
       prefix: "TARGET_INTERVALS="

--- a/tools/picard-CollectHsMetrics.cwl
+++ b/tools/picard-CollectHsMetrics.cwl
@@ -1,0 +1,57 @@
+#!/usr/bin/env cwl-runner
+# https://broadinstitute.github.io/picard/command-line-overview.html#CollectHsMetrics
+
+cwlVersion: v1.0
+class: CommandLineTool
+
+requirements:
+- class: DockerRequirement
+  dockerPull: dukegcb/picard:2.10.7
+- class: InlineJavascriptRequirement
+
+inputs:
+  input_file:
+    type: File
+    doc: "The BAM or SAM file to collect metrics from.  Required."
+    inputBinding:
+      prefix: "I="
+      shellQuote: false
+  output_filename:
+    type: string?
+    doc: "The metrics output filename."
+    default: "hs_metrics.txt"
+    inputBinding:
+      prefix: "O="
+      shellQuote: false
+  reference_sequence:
+    type: File
+    doc: "The reference sequences in fasta format."
+    inputBinding:
+      prefix: "R="
+      shellQuote: false
+  bait_intervals:
+    type: File
+    doc: "The bait interval file in picard interval_list format (from capture kit)."
+    inputBinding:
+      prefix: "BAIT_INTERVALS="
+      shellQuote: false
+  target_intervals:
+    type: File
+    doc: "The target interval file in picard interval_list format (from capture kit)."
+    inputBinding:
+      prefix: "TARGET_INTERVALS="
+      shellQuote: false
+outputs:
+  sorted:
+    type: File
+    outputBinding:
+      glob: $(inputs.output_filename)
+
+baseCommand: ["java", "-Xmx4g"]
+arguments:
+- valueFrom: "/opt/picard/picard.jar"
+  position: -1
+  prefix: -jar
+- valueFrom: CollectHsMetrics
+  position: 0
+

--- a/workflows/exomeseq-01-preprocessing.cwl
+++ b/workflows/exomeseq-01-preprocessing.cwl
@@ -32,6 +32,8 @@ inputs:
   knownSites: File[] # vcf files of known sites, with indexing
   # Variant Recalibration - Common
   resource_dbsnp: File
+  bait_intervals: File
+  target_intervals: File
 outputs:
   qc_reports:
     type: File[]
@@ -98,6 +100,7 @@ steps:
       - recal_reads_output_filename
       - recal_table_output_filename
       - raw_variants_output_filename
+      - hs_metrics_output_filename
   map:
     run: ../tools/bwa-mem-samtools.cwl
     requirements:
@@ -142,6 +145,22 @@ steps:
     out:
       - output_dedup_bam_file
       - output_metrics_file
+  collect_hs_metrics:
+    run: ../tools/picard-CollectHsMetrics.cwl
+    requirements:
+      - class: ResourceRequirement
+        coresMin: 1
+        ramMin: 4000
+        outdirMin: 12000
+        tmpdirMin: 12000
+    in:
+      input_file: output_dedup_bam_file
+      reference_sequence: reference_genome
+      bait_intervals: bait_intervals
+      target_intervals: target_intervals
+      output_filename: generate_sample_filenames/hs_metrics_output_filename
+    out:
+      - output_hs_metrics_file
   # Now recalibrate
   recalibrate_01_analyze:
     run: ../tools/GATK-BaseRecalibrator.cwl

--- a/workflows/exomeseq-01-preprocessing.cwl
+++ b/workflows/exomeseq-01-preprocessing.cwl
@@ -160,6 +160,8 @@ steps:
     in:
       input_file: intervals
       reference_sequence: reference_genome
+      output_filename:
+        default: "target.interval_list"
     out:
       - output_interval_list_file
   make_bait_interval_list:
@@ -173,6 +175,8 @@ steps:
     in:
       input_file: primary_intervals
       reference_sequence: reference_genome
+      output_filename:
+        default: "bait.interval_list"
     out:
       - output_interval_list_file
   collect_hs_metrics:

--- a/workflows/exomeseq-01-preprocessing.cwl
+++ b/workflows/exomeseq-01-preprocessing.cwl
@@ -160,8 +160,6 @@ steps:
     in:
       input_file: intervals
       reference_sequence: reference_genome
-      output_filename:
-        default: "target.interval_list"
     out:
       - output_interval_list_file
   make_bait_interval_list:
@@ -175,8 +173,6 @@ steps:
     in:
       input_file: primary_intervals
       reference_sequence: reference_genome
-      output_filename:
-        default: "bait.interval_list"
     out:
       - output_interval_list_file
   collect_hs_metrics:

--- a/workflows/exomeseq.cwl
+++ b/workflows/exomeseq.cwl
@@ -64,6 +64,12 @@ inputs:
     type: File
     secondaryFiles:
     - .idx
+   # capture kit bait intervals - picard interval_list format
+   bait_intervals:
+     type: File
+   # capture kit target intervals - picard interval_list format
+   target_intervals:
+     type: File
 outputs:
   qc_reports:
     type: { type: array, items: { type: array, items: File } }

--- a/workflows/exomeseq.cwl
+++ b/workflows/exomeseq.cwl
@@ -9,8 +9,10 @@ requirements:
   - class: ScatterFeatureRequirement
   - class: SubworkflowFeatureRequirement
 inputs:
-  # Intervals should come from capture kit
+  # Intervals should come from capture kit (target intervals) bed format
   intervals: File[]?
+  # Intervals should come from capture kit (bait intervals) bed format
+  primary_intervals: File[]?
   interval_padding: int?
   # Read pairs, fastq format
   read_pairs:
@@ -64,16 +66,13 @@ inputs:
     type: File
     secondaryFiles:
     - .idx
-   # capture kit bait intervals - picard interval_list format
-   bait_intervals:
-     type: File
-   # capture kit target intervals - picard interval_list format
-   target_intervals:
-     type: File
 outputs:
   qc_reports:
     type: { type: array, items: { type: array, items: File } }
     outputSource: preprocessing/qc_reports
+  hs_metrics:
+    type: { type: array, items: { type: array, items: File } }
+    outputSource: preprocessing/hs_metrics
   trim_reports:
     type: { type: array, items: { type: array, items: File } }
     outputSource: preprocessing/trim_reports
@@ -146,6 +145,7 @@ steps:
       - recalibration_table
       - recalibrated_reads
       - raw_variants
+      - hs_metrics
   variant_discovery:
     run: exomeseq-02-variantdiscovery.cwl
     in:

--- a/workflows/exomeseq.cwl
+++ b/workflows/exomeseq.cwl
@@ -129,6 +129,7 @@ steps:
     scatter: reads
     in:
       intervals: intervals
+      primary_intervals: primary_intervals
       interval_padding: interval_padding
       reads: read_pairs
       reference_genome: reference_genome


### PR DESCRIPTION
Adds picard CollectHsMetrics step to the workflow.
This requires two files in interval_list format.
Adds steps to convert the bed files to the picard interval_list format.
