### PR TITLE
Fix duplicate hints section in trim_galore.cwl

### DIFF
--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -3351,6 +3351,10 @@
             "class": "CommandLineTool", 
             "hints": [
                 {
+                    "class": "DockerRequirement", 
+                    "dockerPull": "dukegcb/trim-galore:0.4.4"
+                }, 
+                {
                     "class": "SoftwareRequirement", 
                     "packages": [
                         {

--- a/tools/trim_galore.cwl
+++ b/tools/trim_galore.cwl
@@ -5,9 +5,9 @@ class: CommandLineTool
 hints:
   - class: DockerRequirement
     dockerPull: 'dukegcb/trim-galore:0.4.4'
-hints:
-- class: SoftwareRequirement
-  packages:
+
+  - class: SoftwareRequirement
+    packages:
       trimgalore:
         version: [ "0.4.4" ]
         s:citation: https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/


### PR DESCRIPTION
Trim Galore had its DockerRequirement as a hint, which got dropped when packing the workflow due to a duplicate hints section.