### PR TITLE
Puts HaplotypeCaller in single-thread mode

### DIFF
--- a/packed-workflows/exomeseq-packed.cwl
+++ b/packed-workflows/exomeseq-packed.cwl
@@ -1204,7 +1204,6 @@
                         "int"
                     ], 
                     "doc": "controls the number of CPU threads allocated to each data thread", 
-                    "default": 4, 
                     "inputBinding": {
                         "position": 2, 
                         "prefix": "-nct"
@@ -3943,7 +3942,7 @@
                     "requirements": [
                         {
                             "class": "ResourceRequirement", 
-                            "coresMin": 4, 
+                            "coresMin": 1, 
                             "ramMin": 16384
                         }
                     ], 
@@ -3955,10 +3954,6 @@
                         {
                             "source": "#exomeseq-01-preprocessing.cwl/generate_sample_filenames/haplotypes_bam_output_filename", 
                             "id": "#exomeseq-01-preprocessing.cwl/variant_calling/bamOutput"
-                        }, 
-                        {
-                            "default": 8, 
-                            "id": "#exomeseq-01-preprocessing.cwl/variant_calling/cpu_threads"
                         }, 
                         {
                             "source": "#exomeseq-01-preprocessing.cwl/resource_dbsnp", 

--- a/tools/GATK-HaplotypeCaller.cwl
+++ b/tools/GATK-HaplotypeCaller.cwl
@@ -409,7 +409,6 @@ inputs: # position 0, for java args, 1 for the jar, 2 for the tool itself
   cpu_threads:
     type: int?
     doc: controls the number of CPU threads allocated to each data thread
-    default: 4 # Recommended by https://software.broadinstitute.org/gatk/documentation/article?id=1975
     inputBinding:
       position: 2
       prefix: -nct

--- a/workflows/exomeseq-01-preprocessing.cwl
+++ b/workflows/exomeseq-01-preprocessing.cwl
@@ -240,7 +240,7 @@ steps:
     run: ../tools/GATK-HaplotypeCaller.cwl
     requirements:
       - class: ResourceRequirement
-        coresMin: 4
+        coresMin: 1
         ramMin: 16384
     in:
       GATKJar: GATKJar
@@ -248,8 +248,6 @@ steps:
       intervals: intervals
       interval_padding: interval_padding
       reference: reference_genome
-      cpu_threads:
-        default: 8
       group:
         default: ['StandardAnnotation','AS_StandardAnnotation']
       dbsnp: resource_dbsnp


### PR DESCRIPTION
When using BAM output, haplotypecaller can not use multiple threads

Fixes #38