### PR TITLE
Remove library name 'testproj' from bespin.json

### DIFF
--- a/examples/exome-seq/exomeseq-bespin.json
+++ b/examples/exome-seq/exomeseq-bespin.json
@@ -34,7 +34,6 @@
       "path": "/data/exome-seq/b37/1000G_phase1.indels.b37.vcf"
     }
   ],
-  "library": "testproj",
   "platform": "Illumina",
   "reference_genome": {
     "class": "File",


### PR DESCRIPTION
This hard-coded constant is not appropriate for real-world use. Users will need to supply a library/proejct name.