### PR TITLE
Optimize concat-gz-files to avoid decompress/recompress of a single file

### DIFF
--- a/tools/concat-gz-files.cwl
+++ b/tools/concat-gz-files.cwl
@@ -5,7 +5,11 @@ requirements:
     listing:
       - entryname: combinefiles.sh
         entry: |
-          zcat "$@" | gzip
+          if [ "$#" -eq 1 ]; then
+            cat "$@"
+          else
+            zcat "$@" | gzip
+          fi
 baseCommand: bash
 arguments: [combinefiles.sh]
 inputs:


### PR DESCRIPTION
if only one file is specified, this step could ideally be skipped. In the meantime, it's much quicker to simply `cat` the single file to stdout rather than `zcat | gzip`