### PR TITLE
Lower BWA memory to 14GB

### DIFF
--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -140,7 +140,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: $(inputs.threads)
-        ramMin: 16384
+        ramMin: 14336
         outdirMin: 12288
         tmpdirMin: 12288
     in:


### PR DESCRIPTION
For purposes of running in k8s, this fits better onto a node.