### PR TITLE
Raise other picard memory limits on 0.9.2

### DIFF
--- a/subworkflows/exomeseq-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-01-preprocessing.cwl
@@ -150,7 +150,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 1
-        ramMin: 4000
+        ramMin: 6000
         outdirMin: 12000
         tmpdirMin: 12000
     in:
@@ -165,7 +165,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 1
-        ramMin: 4000
+        ramMin: 6000
         outdirMin: 12000
         tmpdirMin: 12000
     in:


### PR DESCRIPTION
- Suspect these were using more than their limit, causing other tool allocations to fail