### PR TITLE
increase map/bwa step to 32GiB

### DIFF
--- a/subworkflows/exomeseq-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-01-preprocessing.cwl
@@ -121,7 +121,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 8
-        ramMin: 24576
+        ramMin: 32768
         outdirMin: 12000
         tmpdirMin: 12000
     in:


### PR DESCRIPTION
Increases memory requirements to 32 GiB to fix out of memory errors seen in production. 